### PR TITLE
Fix FLINT_jll compat entry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,4 +15,4 @@ FLINT_jll = "e134572f-a0d5-539d-bddf-3cad8db41a82"
 [compat]
 JLLWrappers = "1.2.0"
 julia = "1.0"
-FLINT_jll = "200.700"
+FLINT_jll = "~200.700"


### PR DESCRIPTION
@giordano as a stop gap until a proper fix for BB / BBB can be developed, OK to fix the JLL wrapper here? Then I can (? I hope?) manually submit this new version to the registry?